### PR TITLE
Trashcan contents array should be non-nil

### DIFF
--- a/api/service/service.go
+++ b/api/service/service.go
@@ -31,7 +31,7 @@ func NewDatasetsService(db *sql.DB, orgId int) DatasetsService {
 }
 
 func (s *datasetsService) GetTrashcanPage(ctx context.Context, datasetId string, rootNodeId string, limit int, offset int) (*models.TrashcanPage, error) {
-	trashcan := models.TrashcanPage{Limit: limit, Offset: offset, Messages: []string{}}
+	trashcan := models.TrashcanPage{Limit: limit, Offset: offset, Packages: []models.TrashcanItem{}, Messages: []string{}}
 	err := s.StoreFactory.ExecStoreTx(ctx, s.OrgId, func(q store.DatasetsStore) error {
 		dataset, err := q.GetDatasetByNodeId(ctx, datasetId)
 		if err != nil {

--- a/api/service/service_test.go
+++ b/api/service/service_test.go
@@ -108,6 +108,20 @@ func TestGetTrashcanPageDeleting(t *testing.T) {
 	}
 }
 
+func TestGetTrashcanPageEmpty(t *testing.T) {
+	orgId := 7
+	mockFactory := MockFactory{mockStore: &MockDatasetsStore{
+		GetDatasetByNodeIdReturn:           MockReturn[*pgdb.Dataset]{Value: &pgdb.Dataset{Id: 17}},
+		CountDatasetPackagesByStatesReturn: MockReturn[int]{Value: 0},
+	}}
+	service := NewDatasetsServiceWithFactory(&mockFactory, orgId)
+	page, err := service.GetTrashcanPage(context.Background(), "N:dataset:dddd", "", 100, 0)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, page.Packages)
+		assert.Empty(t, page.Packages)
+	}
+}
+
 func TestGetTrashcanPageErrors(t *testing.T) {
 	orgId := 7
 	for tName, expected := range map[string]struct {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,7 +14,9 @@ go test -v ./...; exit_status=$((exit_status || $? ))
 
 cd "$root_dir/api"
 echo "RUNNING api TESTS"
-go test -v ./...; exit_status=$((exit_status || $? ))
+# using -p=1 because more than one package's tests share the same postgres/docker instance
+# and would occasionally interfere with each other.
+go test -v -p=1 ./...; exit_status=$((exit_status || $? ))
 
 exit $exit_status
 


### PR DESCRIPTION
We are returning a nil value for the Packages array field of the `/datasets/trashcan` response if the dataset has no deleted or deleting files. This PR make sure that the Packages array is empty instead of nil in this case.