### PR TITLE
remove folders from manifest file

### DIFF
--- a/api/service/service.go
+++ b/api/service/service.go
@@ -1,170 +1,173 @@
 package service
 
 import (
-    "context"
-    "database/sql"
-    "github.com/aws/aws-sdk-go-v2/service/s3"
-    "github.com/pennsieve/datasets-service/api/models"
-    "github.com/pennsieve/datasets-service/api/store"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
-    "github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-    "strings"
-    "time"
+	"context"
+	"database/sql"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/pennsieve/datasets-service/api/models"
+	"github.com/pennsieve/datasets-service/api/store"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	"strings"
+	"time"
 )
 
 type DatasetsService interface {
-    GetDataset(ctx context.Context, datasetNodeId string) (*pgdb.Dataset, error)
-    GetTrashcanPage(ctx context.Context, datasetNodeId string, rootNodeId string, limit int, offset int) (*models.TrashcanPage, error)
-    GetManifest(ctx context.Context, datasetNodeId string) (*models.ManifestResult, error)
+	GetDataset(ctx context.Context, datasetNodeId string) (*pgdb.Dataset, error)
+	GetTrashcanPage(ctx context.Context, datasetNodeId string, rootNodeId string, limit int, offset int) (*models.TrashcanPage, error)
+	GetManifest(ctx context.Context, datasetNodeId string) (*models.ManifestResult, error)
 }
 
 type datasetsService struct {
-    StoreFactory     store.DatasetsStoreFactory
-    S3StoreFactory   store.S3StoreFactory
-    OrgId            int
-    S3ManifestBucket string
+	StoreFactory     store.DatasetsStoreFactory
+	S3StoreFactory   store.S3StoreFactory
+	OrgId            int
+	S3ManifestBucket string
 }
 
 func NewDatasetsServiceWithFactory(factory store.DatasetsStoreFactory, s3factory store.S3StoreFactory, ssmVars models.HandlerSSMVars, orgId int) DatasetsService {
-    return &datasetsService{StoreFactory: factory, S3StoreFactory: s3factory, S3ManifestBucket: ssmVars.S3Bucket, OrgId: orgId}
+	return &datasetsService{StoreFactory: factory, S3StoreFactory: s3factory, S3ManifestBucket: ssmVars.S3Bucket, OrgId: orgId}
 }
 
 func NewDatasetsService(db *sql.DB, s3Client *s3.Client, ssmVars models.HandlerSSMVars, orgId int) DatasetsService {
-    str := store.NewDatasetsStoreFactory(db, s3Client)
+	str := store.NewDatasetsStoreFactory(db, s3Client)
 
-    s3factory := store.NewS3StoreFactory(s3Client)
+	s3factory := store.NewS3StoreFactory(s3Client)
 
-    datasetsSvc := NewDatasetsServiceWithFactory(str, s3factory, ssmVars, orgId)
-    return datasetsSvc
+	datasetsSvc := NewDatasetsServiceWithFactory(str, s3factory, ssmVars, orgId)
+	return datasetsSvc
 }
 
 func (s *datasetsService) GetTrashcanPage(ctx context.Context, datasetId string, rootNodeId string, limit int, offset int) (*models.TrashcanPage, error) {
-    trashcan := models.TrashcanPage{Limit: limit, Offset: offset, Packages: []models.TrashcanItem{}, Messages: []string{}}
-    err := s.StoreFactory.ExecStoreTx(ctx, s.OrgId, func(q store.DatasetsStore) error {
-        dataset, err := q.GetDatasetByNodeId(ctx, datasetId)
-        if err != nil {
-            return err
-        }
-        deletedCount, err := q.CountDatasetPackagesByStates(ctx, dataset.Id, []packageState.State{packageState.Deleted, packageState.Deleting})
-        if err != nil || deletedCount == 0 {
-            return err
-        }
-        var page *store.PackagePage
-        if len(rootNodeId) == 0 {
-            page, err = q.GetTrashcanRootPaginated(ctx, dataset.Id, limit, offset)
-        } else {
-            rootPckg, pckgErr := q.GetDatasetPackageByNodeId(ctx, dataset.Id, rootNodeId)
-            if pckgErr != nil {
-                return pckgErr
-            }
-            if rootPckg.PackageType != packageType.Collection {
-                return models.FolderNotFoundError{OrgId: s.OrgId, NodeId: rootNodeId, DatasetId: models.DatasetNodeId(datasetId), ActualType: rootPckg.PackageType}
-            }
-            page, err = q.GetTrashcanPaginated(ctx, dataset.Id, rootPckg.Id, limit, offset)
-        }
-        if err != nil {
-            return err
-        }
-        packages := make([]models.TrashcanItem, len(page.Packages))
-        for i, p := range page.Packages {
-            packages[i] = models.TrashcanItem{
-                ID:     p.Id,
-                Name:   p.Name,
-                NodeId: p.NodeId,
-                Type:   p.PackageType.String(),
-                State:  p.PackageState.String(),
-            }
-        }
-        trashcan.TotalCount = page.TotalCount
-        trashcan.Packages = packages
-        return nil
-    })
-    return &trashcan, err
+	trashcan := models.TrashcanPage{Limit: limit, Offset: offset, Packages: []models.TrashcanItem{}, Messages: []string{}}
+	err := s.StoreFactory.ExecStoreTx(ctx, s.OrgId, func(q store.DatasetsStore) error {
+		dataset, err := q.GetDatasetByNodeId(ctx, datasetId)
+		if err != nil {
+			return err
+		}
+		deletedCount, err := q.CountDatasetPackagesByStates(ctx, dataset.Id, []packageState.State{packageState.Deleted, packageState.Deleting})
+		if err != nil || deletedCount == 0 {
+			return err
+		}
+		var page *store.PackagePage
+		if len(rootNodeId) == 0 {
+			page, err = q.GetTrashcanRootPaginated(ctx, dataset.Id, limit, offset)
+		} else {
+			rootPckg, pckgErr := q.GetDatasetPackageByNodeId(ctx, dataset.Id, rootNodeId)
+			if pckgErr != nil {
+				return pckgErr
+			}
+			if rootPckg.PackageType != packageType.Collection {
+				return models.FolderNotFoundError{OrgId: s.OrgId, NodeId: rootNodeId, DatasetId: models.DatasetNodeId(datasetId), ActualType: rootPckg.PackageType}
+			}
+			page, err = q.GetTrashcanPaginated(ctx, dataset.Id, rootPckg.Id, limit, offset)
+		}
+		if err != nil {
+			return err
+		}
+		packages := make([]models.TrashcanItem, len(page.Packages))
+		for i, p := range page.Packages {
+			packages[i] = models.TrashcanItem{
+				ID:     p.Id,
+				Name:   p.Name,
+				NodeId: p.NodeId,
+				Type:   p.PackageType.String(),
+				State:  p.PackageState.String(),
+			}
+		}
+		trashcan.TotalCount = page.TotalCount
+		trashcan.Packages = packages
+		return nil
+	})
+	return &trashcan, err
 }
 
 func (s *datasetsService) GetDataset(ctx context.Context, datasetId string) (*pgdb.Dataset, error) {
-    q := s.StoreFactory.NewSimpleStore(s.OrgId)
-    return q.GetDatasetByNodeId(ctx, datasetId)
+	q := s.StoreFactory.NewSimpleStore(s.OrgId)
+	return q.GetDatasetByNodeId(ctx, datasetId)
 }
 
 func (s *datasetsService) GetManifest(ctx context.Context, datasetNodeId string) (*models.ManifestResult, error) {
-    q := s.StoreFactory.NewSimpleStore(s.OrgId)
-    s3 := s.S3StoreFactory.NewSimpleStore(s.S3ManifestBucket)
+	q := s.StoreFactory.NewSimpleStore(s.OrgId)
+	s3 := s.S3StoreFactory.NewSimpleStore(s.S3ManifestBucket)
 
-    ds, _ := q.GetDatasetByNodeId(ctx, datasetNodeId)
+	ds, _ := q.GetDatasetByNodeId(ctx, datasetNodeId)
 
-    manifest, err := q.GetDatasetManifest(ctx, ds.Id)
+	manifest, err := q.GetDatasetManifest(ctx, ds.Id)
 
-    // Map each entry to packageID for lookup to create path
-    manifestMap := make(map[int]models.DatasetManifest)
-    for i := 0; i < len(manifest); i++ {
-        manifestMap[manifest[i].PackageId] = manifest[i]
-    }
+	// Map each entry to packageID for lookup to create path
+	manifestMap := make(map[int]models.DatasetManifest)
+	for i := 0; i < len(manifest); i++ {
+		manifestMap[manifest[i].PackageId] = manifest[i]
+	}
 
-    // Generate ManifestDTO which includes full path for files
-    var results []models.ManifestDTO
-    for i, _ := range manifest {
-        var sb strings.Builder
-        for pathIndex, _ := range manifest[i].Path {
-            if manifest[i].Path[pathIndex].Valid {
-                if pathIndex > 1 {
-                    sb.WriteString("/")
-                }
-                sb.WriteString(manifestMap[int(manifest[i].Path[pathIndex].Int64)].PackageName)
-            }
-        }
+	// Generate ManifestDTO which includes full path for files
+	var results []models.ManifestDTO
+	for i, _ := range manifest {
 
-        results = append(results, models.ManifestDTO{
-            PackageName:   manifest[i].PackageName,
-            FileName:      manifest[i].FileName,
-            Path:          sb.String(),
-            PackageNodeId: manifest[i].PackageNodeId,
-            Size:          manifest[i].Size,
-            CheckSum:      manifest[i].CheckSum,
-        })
+		if !strings.HasPrefix(manifest[i].PackageNodeId, "N:collection") {
+			var sb strings.Builder
+			for pathIndex, _ := range manifest[i].Path {
+				if manifest[i].Path[pathIndex].Valid {
+					if pathIndex > 1 {
+						sb.WriteString("/")
+					}
+					sb.WriteString(manifestMap[int(manifest[i].Path[pathIndex].Int64)].PackageName)
+				}
+			}
 
-    }
+			results = append(results, models.ManifestDTO{
+				PackageName:   manifest[i].PackageName,
+				FileName:      manifest[i].FileName,
+				Path:          sb.String(),
+				PackageNodeId: manifest[i].PackageNodeId,
+				Size:          manifest[i].Size,
+				CheckSum:      manifest[i].CheckSum,
+			})
+		}
 
-    license := "N/A"
-    if ds.License.Valid {
-        license = ds.License.String
-    }
+	}
 
-    description := "N/A"
-    if ds.Description.Valid {
-        description = ds.Description.String
-    }
+	license := "N/A"
+	if ds.License.Valid {
+		license = ds.License.String
+	}
 
-    workspaceManifest := models.WorkspaceManifest{
-        Date:          models.JSONDate(time.Now()),
-        DatasetId:     ds.Id,
-        DatasetNodeId: datasetNodeId,
-        Name:          ds.Name,
-        Description:   description,
-        License:       license,
-        Contributors:  ds.Contributors,
-        Tags:          ds.Tags,
-        Files:         results,
-    }
+	description := "N/A"
+	if ds.Description.Valid {
+		description = ds.Description.String
+	}
 
-    // Write JSON file to S3
-    writeOutput, err := s3.WriteManifestToS3(ctx, datasetNodeId, workspaceManifest)
-    if err != nil {
-        return nil, err
-    }
+	workspaceManifest := models.WorkspaceManifest{
+		Date:          models.JSONDate(time.Now()),
+		DatasetId:     ds.Id,
+		DatasetNodeId: datasetNodeId,
+		Name:          ds.Name,
+		Description:   description,
+		License:       license,
+		Contributors:  ds.Contributors,
+		Tags:          ds.Tags,
+		Files:         results,
+	}
 
-    // Create Presigned URL for file on S3
-    presignedUrl, err := s3.GetPresignedUrl(ctx, writeOutput.S3Bucket, writeOutput.S3Key)
-    if err != nil {
-        return nil, err
-    }
+	// Write JSON file to S3
+	writeOutput, err := s3.WriteManifestToS3(ctx, datasetNodeId, workspaceManifest)
+	if err != nil {
+		return nil, err
+	}
 
-    result := models.ManifestResult{
-        Url:      presignedUrl.String(),
-        S3Bucket: writeOutput.S3Bucket,
-        S3Key:    writeOutput.S3Key,
-    }
-    return &result, nil
+	// Create Presigned URL for file on S3
+	presignedUrl, err := s3.GetPresignedUrl(ctx, writeOutput.S3Bucket, writeOutput.S3Key)
+	if err != nil {
+		return nil, err
+	}
+
+	result := models.ManifestResult{
+		Url:      presignedUrl.String(),
+		S3Bucket: writeOutput.S3Bucket,
+		S3Key:    writeOutput.S3Key,
+	}
+	return &result, nil
 
 }

--- a/api/service/service_test.go
+++ b/api/service/service_test.go
@@ -211,7 +211,7 @@ func TestGetManifest(t *testing.T) {
 	// Reading file from S3 which should contain array of manifestFile objects
 	testResult, err := readS3Object(s3Client, actual.S3Bucket, actual.S3Key)
 	assert.NoError(t, err)
-	assert.Len(t, testResult.Files, 10, "Unexpected length of manifest file array from S3.")
+	assert.Len(t, testResult.Files, 6, "Unexpected length of manifest file array from S3.")
 
 	// Check name for single package
 	check := false


### PR DESCRIPTION
* Removing folders from manifest file output

Manifest folders are returned by the SQL query as we need them to derive the paths for the files. However, we should not include them in the JSON manifest file. 